### PR TITLE
Update webpack.config.js

### DIFF
--- a/Chapter02/chapter2_1/webpack.config.js
+++ b/Chapter02/chapter2_1/webpack.config.js
@@ -5,9 +5,14 @@ module.exports = {
     path: path.resolve('dist'),
     filename: 'main.js'
   },
+  devServer: {
+    disableHostCheck: true
+  },
   module: {
-    loaders: [
-      { test: /\.jsx?$/, loader: 'babel-loader', exclude: /node_modules/ }
-    ]
+    rules: [{
+      test: /\.jsx?$/,
+      loader: 'babel-loader',
+      exclude: /node_modules/
+    }]
   }
 }


### PR DESCRIPTION
Changes in version 2.5.0:
- loaders => rules
- added the disableHostCheck: true property, because it was throwing an error in the console, and kept checking the host (see https://stackoverflow.com/questions/53906803/webpack-4-hot-reload-invalid-host-origin-header/53907054#53907054)